### PR TITLE
feat: add colors to usernames and timestamps in chat

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,15 @@ module github.com/mdxabu/twich
 go 1.25.5
 
 require (
+	github.com/fatih/color v1.18.0
 	github.com/gempir/go-twitch-irc/v4 v4.3.1
 	github.com/spf13/cobra v1.10.2
 )
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	golang.org/x/sys v0.29.0 // indirect
 )

--- a/internals/chatFetcher.go
+++ b/internals/chatFetcher.go
@@ -3,6 +3,7 @@ package chat
 import (
 	"fmt"
 
+	"github.com/fatih/color"
 	"github.com/gempir/go-twitch-irc/v4"
 )
 
@@ -10,8 +11,14 @@ import (
 func FetchChat(username string) {
 	client := twitch.NewAnonymousClient()
 
+	// Define colors for timestamp and username
+	cyan := color.New(color.FgCyan).SprintFunc()
+	yellow := color.New(color.FgYellow).SprintFunc()
+
 	client.OnPrivateMessage(func(message twitch.PrivateMessage) {
-		fmt.Println(message.Time.Local().Format("15:04:05")+" [" + message.User.DisplayName + "]: " + message.Message)
+		timestamp := cyan(message.Time.Local().Format("15:04:05"))
+		displayName := yellow(message.User.DisplayName)
+		fmt.Printf("%s [%s]: %s\n", timestamp, displayName, message.Message)
 	})
 
 	client.Join(username)


### PR DESCRIPTION
## Description
This PR adds colorized output to the chat display as requested in issue #1.

## Changes
- Added `fatih/color` dependency to `go.mod` for cross-platform color support
- Updated `chatFetcher.go` to colorize:
  - **Timestamps**: Cyan color for better visibility
  - **Usernames**: Yellow color to distinguish from message content
- Used `fmt.Printf` instead of `fmt.Println` for cleaner formatting

## Testing
The changes use the `fatih/color` library which automatically handles:
- Windows (via colorable library)
- Unix/Linux terminals
- No-color fallback when output is redirected

## Visual Example
Before:
```
15:04:05 [Username]: Hello world
```

After:
```
15:04:05 [Username]: Hello world
^cyan     ^yellow    ^default
```

Closes #1

Signed-off-by: openclaw-ai-dev <openclaw-ai-dev@users.noreply.github.com>